### PR TITLE
Add m_delaymsg module

### DIFF
--- a/modules.conf
+++ b/modules.conf
@@ -111,6 +111,7 @@
 <title name="anonymous" password="" vhost="anonymous">
 
 
+<module name="m_delaymsg.so">
 <module name="m_devoice.so">
 <module name="m_globops.so">
 <module name="m_halfop.so">


### PR DESCRIPTION
Provides channelmode +d <int>, to deny messages to a channel until <int>
seconds.